### PR TITLE
Accommodate for bigger boot-loaders to be written

### DIFF
--- a/src/bin/sdcard.rs
+++ b/src/bin/sdcard.rs
@@ -64,7 +64,7 @@ const KEYS_EVDEV_PATH: &str = "/dev/input/event0";
 const ROOTFS_PATH: &str = "/dev/mmcblk0p2";
 const BOOTLOADER_PATH: &str = "/dev/mmcblk0";
 const BOOTLOADER_OFFSET: u64 = 8192; // Boot ROM expects this offset, so it will never change
-const BOOTLOADER_SIZE: u64 = 5 * 64 * 2048;
+const BOOTLOADER_SIZE: u64 = 6 * 64 * 2048;
 
 /// Set up the basic environment (e.g. mount points).
 fn setup_initramfs() -> anyhow::Result<()> {


### PR DESCRIPTION
The changes i've added to support loading different dts's grew the bootloader over the size specified here. It took me quite a while to figure out the installer was not copying all bytes.
